### PR TITLE
Added Payment route and updated Controllers

### DIFF
--- a/server/controllers/paymentController.js
+++ b/server/controllers/paymentController.js
@@ -1,5 +1,9 @@
 const stripe = require("stripe")(process.env.STRIPE_SECRET_KEY);
 const createError = require("http-errors");
+const Profile = require("../models/profileModel");
+
+//Here CUSTOMER and ACCOUNT are two separate instances of Stripe user representation.
+//According to the app - owner can only be "customer", while siiter may have both "customer" and "account" instances
 
 //retrieve a customer by searching their email
 exports.getCustomer = async (req, res, next) => {
@@ -11,30 +15,56 @@ exports.getCustomer = async (req, res, next) => {
       email: email,
       description: "Dog sitter service customer",
     };
+    //check if Customer exists in Stripe
     let existingCustomer = await stripe.customers.list({
       email: email,
     });
+
     if (existingCustomer.data.length > 0) {
       //customer exists -> retrieve their cards
       const cards = await stripe.customers.listSources(id, {
         object: "card",
         limit: 5,
       });
-      const customerCards = await cards.data.map(card => {
+      //map cards to send in response
+      let customerCards = await cards.data.map(card => {
         return {
           id: card.id,
           brand: card.brand,
           month: card.exp_month.toString(),
           year: card.exp_year.toString(),
           last4: card.last4,
+          funding: card.funding,
+          payout: false,
           isDefault:
             existingCustomer.data[0].default_source == card.id ? true : false,
         };
       });
-      res.json({ error: false, cards: customerCards });
+      //if customer also has a connected account for payouts (applicable to sitters only)
+      if (existingCustomer.data[0].metadata.hasOwnProperty("accountId")) {
+        let accountCards = await stripe.accounts.listExternalAccounts(
+          existingCustomer.data[0].metadata.accountId,
+          { object: "card", limit: 1 }
+        );
+        //add their payout card to represent on FE
+        if (accountCards) {
+          await customerCards.push({
+            id: accountCards.data[0].id,
+            brand: accountCards.data[0].brand,
+            month: accountCards.data[0].exp_month.toString(),
+            year: accountCards.data[0].exp_year.toString(),
+            last4: accountCards.data[0].last4,
+            funding: accountCards.data[0].funding,
+            payout: true,
+            isDefault: false,
+          });
+        }
+      }
+
+      return res.json({ error: false, cards: customerCards });
     } else {
       //customer doesn't exist yet -> create new customer
-      await stripe.customers.create(customerInfo, (err, data) => {
+      await stripe.customers.create(customerInfo, async (err, data) => {
         if (err) {
           next(createError(500, err.message));
         }
@@ -49,32 +79,137 @@ exports.getCustomer = async (req, res, next) => {
       });
     }
   } catch (err) {
-    res.json({ error: true, message: err.raw.message });
+    next(createError(500, err.message));
   }
 };
 
 //add new card
-exports.addCard = async (req, res) => {
+exports.addCard = async (req, res, next) => {
   try {
-    const { userId, token } = req.body;
+    const { userId, profileId, token, email, payoutCard } = req.body;
+    //retrieve user's information from thei customer instance
+    let existingCustomer = await stripe.customers.list({
+      email: email,
+    });
+    //retrieve profile's info to fill up connected account input fields
+    const profile = await Profile.findById(profileId);
+    //sitter sends the debit card data AND checks the card to be payout card
+    if (profile.isSitter && payoutCard) {
+      //check if sitter has never added payout card
+      if (!existingCustomer.data[0].metadata.hasOwnProperty("accountId")) {
+        if (token.card.funding === "debit") {
+          //there is no account associated with the customer and they add debit PAYOUT card - create an account
+          const account = await stripe.accounts.create({
+            country: "CA",
+            type: "custom",
+            business_type: "individual",
+            email: email,
+            default_currency: "cad",
+            individual: {
+              dob: {
+                day: profile.birthDate.getDate(),
+                month: profile.birthDate.getMonth(),
+                year: profile.birthDate.getFullYear(),
+              },
+              first_name: profile.firstName,
+              last_name: profile.lastName,
+              address: {
+                city: "Toronto",
+                country: "CA",
+                line1: "Bay str",
+                line2: "20",
+                state: "ON",
+                postal_code: "M5J2N8",
+              },
+            },
+            company: {
+              address: {
+                city: "Toronto",
+                country: "CA",
+                line1: "Bay str",
+                line2: "20",
+                state: "ON",
+                postal_code: "M5J2N8",
+              },
+            },
+            business_profile: {
+              support_address: {
+                city: "Toronto",
+                country: "CA",
+                line1: "Bay str",
+                line2: "20",
+                state: "ON",
+                postal_code: "M5J2N8",
+              },
+            },
+            tos_acceptance: {
+              date: new Date(),
+              ip: token.client_ip,
+            },
+            external_account: token.id,
+            capabilities: {
+              card_payments: {
+                requested: true,
+              },
+              transfers: {
+                requested: true,
+              },
+            },
+          });
+          //update customer's metadata to reflect they have connected account number
+          const updatedCustomer = await stripe.customers.update(userId, {
+            metadata: { accountId: account.id },
+          });
+        } else {
+          //User sent CREDIT (or any other non-debit) card as PAYOUT card
+          return res.json({
+            error: true,
+            message: "Only DEBIT card can be added as Payout card",
+          });
+        }
+      }
+      //sitter has an account already - update payout card
+      else {
+        await stripe.accounts.update(
+          existingCustomer.data[0].metadata.accountId,
+          { external_account: token.id }
+        );
+      }
+      return res.json({
+        error: false,
+        data: {
+          id: token.card.id,
+          brand: token.card.brand,
+          month: token.card.exp_month,
+          year: token.card.exp_year,
+          last4: token.card.last4,
+          funding: token.card.funding,
+          payout: true,
+        },
+      });
+    }
+
+    //Owner or sitter sends card data to make payments - "Payout card" field was UNchecked
+    //add card to user's list
     const card = await stripe.customers.createSource(userId, {
       source: token.id,
     });
-    if (card) {
-      res.json({
-        error: false,
-        data: {
-          id: card.id,
-          brand: card.brand,
-          month: card.exp_month,
-          year: card.exp_year,
-          last4: card.last4,
-        },
-      });
-    } else {
-      res.json({ error: true, data: null });
+    if (!card) {
+      return res.json({ error: true, data: null });
     }
-    return;
+
+    return res.json({
+      error: false,
+      data: {
+        id: card.id,
+        brand: card.brand,
+        month: card.exp_month,
+        year: card.exp_year,
+        last4: card.last4,
+        funding: card.funding,
+        payout: false,
+      },
+    });
   } catch (err) {
     res.json({ error: true, message: err.raw.message });
   }

--- a/server/controllers/requestController.js
+++ b/server/controllers/requestController.js
@@ -106,7 +106,12 @@ exports.updateRequest = async (req, res, next) => {
       { _id: req.params.id },
       async (err, data) => {
         if (err) return err;
-
+        if (declined) {
+          updatedRequest.declined = true;
+          updatedRequest.accepted = false;
+          await updatedRequest.save();
+          return res.status(200).send(updatedRequest);
+        }
         await stripe.customers.retrieve(
           req.user.id,
           async (error, customer) => {
@@ -127,11 +132,6 @@ exports.updateRequest = async (req, res, next) => {
                 updatedRequest.accepted = true;
                 updatedRequest.declined = false;
               }
-              if (declined) {
-                updatedRequest.declined = true;
-                updatedRequest.accepted = false;
-              }
-
               await updatedRequest.save();
               res.status(200).send(updatedRequest);
             }

--- a/server/controllers/requestController.js
+++ b/server/controllers/requestController.js
@@ -3,6 +3,7 @@ const Profile = require("../models/profileModel");
 const Request = require("../models/requestModel");
 const User = require("../models/userModel");
 const ObjectId = require("mongoose").Types.ObjectId;
+const stripe = require("stripe")(process.env.STRIPE_SECRET_KEY);
 
 // Get list of requests for logged in user
 exports.getRequests = async (req, res, next) => {
@@ -27,7 +28,6 @@ exports.createRequest = async (req, res, next) => {
   try {
     const { sitterId, start, end } = req.body;
     const ownerId = req.user.id;
-
     // Validate user input
     if (!start || !end) {
       return next(createError(400, "Please provide a start and end date"));
@@ -47,17 +47,26 @@ exports.createRequest = async (req, res, next) => {
       return next(createError(404, "Can't find user!"));
     }
 
-    // Create new request
-    const newRequest = new Request({
-      ownerId,
-      sitterId,
-      start,
-      end,
+    //check if OWNER has their card(s) added
+    await stripe.customers.retrieve(ownerId, async (err, data) => {
+      if (err) {
+        return next(createError(400, "You have not registered payment"));
+      }
+      if (data) {
+        if (!data.default_source) {
+          return next(createError(400, "You have not added payment card"));
+        }
+        // Create new request
+        const newRequest = new Request({
+          ownerId,
+          sitterId,
+          start,
+          end,
+        });
+        const savedRequest = await newRequest.save();
+        res.status(201).send(savedRequest);
+      }
     });
-
-    const savedRequest = await newRequest.save();
-
-    res.status(201).send(savedRequest);
   } catch (err) {
     next(createError(500, err.message));
   }
@@ -67,11 +76,11 @@ exports.createRequest = async (req, res, next) => {
 exports.updateRequest = async (req, res, next) => {
   try {
     const { accepted, declined } = req.body;
-
     // Check if ID is valid
     if (!ObjectId.isValid(req.params.id)) {
       return next(createError(400, "Invalid Request ID!"));
     }
+    //populate data into request
     const request = await Request.findById(req.params.id).populate([
       { path: "sitterId", model: "User", populate: { path: "profile" } },
       { path: "ownerId", model: "User", populate: { path: "profile" } },
@@ -91,21 +100,124 @@ exports.updateRequest = async (req, res, next) => {
         )
       );
     }
-
     // Update request with approved or declined
     // A sitter can decline a request after they've approved it, hence declined is set to the opposite of accepted and vice versa.
-    if (accepted) {
-      request.accepted = true;
-      request.declined = false;
-    }
-    if (declined) {
-      request.declined = true;
-      request.accepted = false;
-    }
+    const updatedRequest = await Request.findById(
+      { _id: req.params.id },
+      async (err, data) => {
+        if (err) return err;
 
-    const updatedRequest = await request.save();
+        await stripe.customers.retrieve(
+          req.user.id,
+          async (error, customer) => {
+            if (error) {
+              return res.status(403).json({
+                error: true,
+                message: "You have not registered payment",
+              });
+            }
+            if (customer) {
+              if (!customer.metadata.hasOwnProperty("accountId")) {
+                return res.status(403).json({
+                  error: true,
+                  message: "You have no payment card added",
+                });
+              }
+              if (accepted) {
+                updatedRequest.accepted = true;
+                updatedRequest.declined = false;
+              }
+              if (declined) {
+                updatedRequest.declined = true;
+                updatedRequest.accepted = false;
+              }
 
-    res.status(200).send(updatedRequest);
+              await updatedRequest.save();
+              res.status(200).send(updatedRequest);
+            }
+          }
+        );
+      }
+    );
+  } catch (err) {
+    next(createError(500, err.message));
+  }
+};
+
+exports.payRequest = async (req, res, next) => {
+  try {
+    //THIS AMOUNT WILL COME FROM BODY
+    const amount = 127.5;
+
+    const fee = Math.round((amount * 0.03 + Number.EPSILON) * 100) / 100;
+    //Retrieve a request
+    await Request.findById(req.params.id, async (err, data) => {
+      if (err)
+        return res.status(500).json({
+          error: true,
+          message: "Database error occured. Please Try again",
+        });
+
+      if (data.paid)
+        return res.status(400).json({
+          error: true,
+          message: "This request was already paid",
+        });
+
+      if (data.accepted && data.end.getTime() < Date.now()) {
+        //Looking for sitter first
+        await stripe.customers.retrieve(
+          data.sitterId.toString(),
+          async (err, sitter) => {
+            if (err)
+              return res.status(400).json({
+                error: true,
+                message: "Unable to pay the sitter",
+              });
+            //Look for owner's customer instance now
+            await stripe.customers.retrieve(
+              req.user.id,
+              async (err, customer) => {
+                if (err)
+                  return res.status(400).json({
+                    error: true,
+                    message: "Unable to make payment",
+                  });
+                //If there is no card added to Owner's account
+                if (!customer.default_source) {
+                  return res.status(403).json({
+                    error: true,
+                    message: "No payment card was found",
+                  });
+                } else {
+                  //make a payment
+                  const paymentIntent = await stripe.paymentIntents.create({
+                    amount: amount * 100,
+                    currency: "cad",
+                    customer: customer.id.toString(),
+                    payment_method: customer.default_source,
+                    description: `Request payment from owner ${customer.id} to sitter ${sitter.id} as per request ${data._id}`,
+                    application_fee_amount: fee * 100,
+                    transfer_data: {
+                      destination: sitter.metadata.accountId,
+                    },
+                    confirm: true,
+                  });
+                  if (!paymentIntent) {
+                    return res.status(403).json({
+                      error: true,
+                      message: "Unable to make payment",
+                    });
+                  }
+                  data.paid = true;
+                  await data.save();
+                }
+              }
+            );
+          }
+        );
+      }
+    });
   } catch (err) {
     next(createError(500, err.message));
   }

--- a/server/routes/requestRouter.js
+++ b/server/routes/requestRouter.js
@@ -12,5 +12,6 @@ router
   .post(requestController.createRequest);
 
 router.put("/:id", requestController.updateRequest);
+router.post("/:id/pay", requestController.payRequest);
 
 module.exports = router;


### PR DESCRIPTION
This PR covers #20 and #88

- Owner can not post request without payment card added
- Sitter can not accept request withoy Payout card attached, but can still decline one

Payments FE: 

- If user is registered as sitter they recieve a hint message (see attached images) which will go away once they add a Payout card (to get payed for services). This Payout card can be changed (checkbox must be checked). The card however won't be used for paying other sitters if user is a dog owner themselves, for that another card will need to be added.
- Only Canadian debit card can be added as Payout card. (Stripe limitations)
- DOB is a requirement from Stripe in order to be able to set Payout card (message will flash if DOB is not set)

Payments BE:

- User can be owner / sitter / owner & sitter. "Customer" instance is created for everyone, while "Account" instance created for sitters only.
- Sitter pay route is /request/:id/pay, where :id - is request id. 
- **Amount was hardcoded so far** (127.5$)
- **Address was hardcoded**, since we do not require users to type in exact address (but Stripe does)

*There are many other details to go over, please view the code and address any concerns in the comments.

![payment1](https://user-images.githubusercontent.com/47538460/106191882-7104a900-6179-11eb-96f3-d91d9672fe61.jpg)
![payment2](https://user-images.githubusercontent.com/47538460/106191891-73670300-6179-11eb-96fb-50f3b57eaaa1.jpg)
![payment3](https://user-images.githubusercontent.com/47538460/106191893-74983000-6179-11eb-9bbb-271ac194bf56.jpg)
![payment4](https://user-images.githubusercontent.com/47538460/106191894-7530c680-6179-11eb-99b5-044274d38a04.jpg)
![payment5](https://user-images.githubusercontent.com/47538460/106191896-7530c680-6179-11eb-9e46-b4eff389e24b.jpg)







